### PR TITLE
Download a Mustache binary, rather than requiring Go

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -34,15 +34,6 @@ jobs:
           - name: Install dependencies
             run: sudo apt install zip bzip2 gzip tar curl bash
 
-          - name: Setup Go
-            uses: actions/setup-go@v2.1.4
-
-          - name: Install Mustache (build dependency)
-            run: go get github.com/cbroglie/mustache/...
-
-          - name: Add Go bin to PATH
-            run: echo 'export PATH="$HOME/go/bin:$PATH"'>>~/.bash_profile
-
           - name: Cache build environment downloads
             id: cache-downloads
             uses: actions/cache@v2
@@ -62,7 +53,7 @@ jobs:
             run: make configure
 
           - name: Build
-            run: MUSTACHE="$HOME/go/bin/mustache" make build
+            run: make build
 
           - name: Upload build artifacts
             uses: actions/upload-artifact@v2

--- a/README.adoc
+++ b/README.adoc
@@ -34,10 +34,6 @@ strengths, ~and an exercise in humility~. See:
     if you want to build locally, it will require an environment that is
     compatible with what you see in Linux, including Bash. Or, just use CI!
 
-  * This build system requires *installing Go*, precisely because of Mustache.
-    Golang is a bit of a heft, and I can understand why this can be a turn-off
-    for people.
-
   * To me it feels a bit *hacky*... though, sure, that is subjective.
 
   * The CI workflow *only works in GitHub*. I'm not shilling Microsoft, it's
@@ -93,10 +89,14 @@ NOTE: This requires Linux or a Linux-like environment.
 
 If you want to build from source, make sure you have the build dependencies
 beforehand. You most likely already have `curl`, `zip`, `tar`, `gzip`, `bash`
-and `bz2`, but you will also need to install a Go package named `mustache`.
+and `bz2`.
 
-You can grab it by https://golang.org/doc/install[installing Go],
-and then running:
+Optionally, you may install a Go package named `mustache`, however if it's not
+found on your `$PATH` already, a pre-compiled binary will be downloaded on
+first build.
+
+For manually setting it up, you can grab it by
+https://golang.org/doc/install[installing Go], and then running:
 
 [source,console]
 ----


### PR DESCRIPTION
Since Go produces stand-alone binaries, it's easier to download a pre-built one than require a full Golang installation.

Adjusted the README to match.

My first time working with a Makefile, so this is likely a massive hack.

It still allows you to specify `MUSTACHE` as an env var if you want to use your own version, however if the target of `MUSTACHE` does not exist, it will download a release specified by `MUSTACHE_VER` into the `build/deps` directory and pass that to `_build.sh`.